### PR TITLE
pseudo-dsl for testing chialisp contracts (first iteration)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ with open("README.md", "rt") as fh:
 
 dependencies = [
     "clvm_tools>=0.4.3",
-    "clvm_rs>=0.1.1"
+    "clvm_rs>=0.1.1",
+    "pytimeparse==1.1.8",
 ]
 
 dev_dependencies = []

--- a/std/examples/standard_transaction.py
+++ b/std/examples/standard_transaction.py
@@ -21,6 +21,7 @@ node.farm_block(public_key)
 
 #Create a puzzle that just outputs a new coin locked up with standard puzzle hash
 delegated_puzzle = Program.to((1, [[ConditionOpcode.CREATE_COIN, puzzle_for_pk(public_key).get_tree_hash(), 250000000000]]))
+solution = Program.to([[], delegated_puzzle, []])
 
 #Sign the (delegated_puzzle_hash + coin_name) with synthetic secret key
 signature = AugSchemeMPL.sign(
@@ -33,12 +34,11 @@ bundle = SpendBundle(
     [
         CoinSolution(
             node.coins[3], #coin being spent
-            puzzle_for_pk(public_key), #puzzle reveal
-            Program.to([[], delegated_puzzle, []]) #puzzle solution
+            puzzle_for_pk(public_key), #puzzle reveal -- the actual puzzle used
+            solution #puzzle solution
         )
     ],
     signature
 )
-
 #Attempt to spend the bundle
 print(node.push_tx(bundle))

--- a/std/sim/node.py
+++ b/std/sim/node.py
@@ -28,6 +28,12 @@ class Node():
 
     def __init__(self):
         self.timestamp = float_to_timestamp(time.time())
+        self.block_height = 0
+        self.timestamp = 0
+        self.blocks = []
+        self.coins = []
+        self.coin_records = []
+        self.mempool = []
 
     def set_block_height(self, block_height: uint32):
         self.block_height = block_height

--- a/std/sim/node.py
+++ b/std/sim/node.py
@@ -27,6 +27,7 @@ class Node():
     mempool: List[SpendBundle] = []
 
     def __init__(self):
+        self.fast_time = False
         self.timestamp = float_to_timestamp(time.time())
         self.block_height = 0
         self.timestamp = 0
@@ -39,6 +40,7 @@ class Node():
         self.block_height = block_height
 
     def set_timestamp(self, timestamp: uint64):
+        self.fast_time = True
         self.timestamp = timestamp
 
     def add_coin(self, coin: Coin):
@@ -156,7 +158,11 @@ class Node():
         self.block_height += 1
 
         # timestamp is reset
-        self.timestamp = float_to_timestamp(time.time())
+        if not self.fast_time:
+            self.timestamp = float_to_timestamp(time.time())
+        else:
+            self.timestamp += 600.0 / 32.0
+
         return {
             'additions': [pool_coin, farmer_coin] + additions,
             'removals': removals
@@ -174,7 +180,7 @@ class Node():
             status = MempoolInclusionStatus.SUCCESS
             error = None
         else:
-            cost, status, error = validate_spendbundle(spend_bundle, removals, self.coin_records, self.block_height)
+            cost, status, error = validate_spendbundle(spend_bundle, removals, self.coin_records, self.block_height, timestamp=self.timestamp)
             if status != MempoolInclusionStatus.SUCCESS:
                 if spend_bundle in self.mempool:
                     # Already in mempool

--- a/std/sim/node.py
+++ b/std/sim/node.py
@@ -51,7 +51,10 @@ class Node():
 
     def remove_coin(self, coin: Coin):
         #Remove the coin from the UTXO set
-        self.coins.remove(coin)
+        old_len = len(self.coins)
+        self.coins = list(filter(lambda x: x.name() != coin.name(), self.coins))
+        assert len(self.coins) == old_len - 1
+
         #Update the coin record
         matching_record = list(filter(lambda e: e.coin == coin,self.coin_records))
         for record in matching_record:
@@ -148,6 +151,10 @@ class Node():
 
         # timestamp is reset
         self.timestamp = float_to_timestamp(time.time())
+        return {
+            'additions': [pool_coin, farmer_coin] + additions,
+            'removals': removals
+        }
 
     def push_tx(self, spend_bundle: SpendBundle):
         spend_name = spend_bundle.name()

--- a/std/sim/spend_bundle_validation.py
+++ b/std/sim/spend_bundle_validation.py
@@ -193,11 +193,6 @@ def validate_spendbundle(new_spend: SpendBundle, mempool_removals: List[Coin], c
     coin_announcements_in_spend: Set[bytes32] = coin_announcements_names_for_npc(npc_list)
     puzzle_announcements_in_spend: Set[bytes32] = puzzle_announcements_names_for_npc(npc_list)
     for npc in npc_list:
-        # XXX this is a hack, but I'm unsure what npc_list represents or why it's
-        # necessarily true that things in it must exist in the remove list.
-        if npc.coin_name not in removal_record_dict:
-                continue
-
         coin_record: CoinRecord = removal_record_dict[npc.coin_name]
         # Check that the revealed removal puzzles actually match the puzzle hash
         if npc.puzzle_hash != coin_record.coin.puzzle_hash:

--- a/std/sim/spend_bundle_validation.py
+++ b/std/sim/spend_bundle_validation.py
@@ -51,7 +51,7 @@ def check_removals(mempool_removals: List[Coin], removals: Dict[bytes32, CoinRec
         return None, []
 
 def validate_transaction(
-    spend_bundle_bytes: bytes,
+    spend_bundle_bytes: bytes
 ) -> bytes:
     # constants: ConsensusConstants = dataclass_from_dict(ConsensusConstants, recurse_jsonify(dataclasses.asdict(ConsensusConstants)))
     # Calculate the cost and fees
@@ -59,7 +59,10 @@ def validate_transaction(
     # npc contains names of the coins removed, puzzle_hashes and their spend conditions
     return bytes(get_name_puzzle_conditions(program, DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM, True))
 
-def validate_spendbundle(new_spend: SpendBundle, mempool_removals: List[Coin], current_coin_records: List[CoinRecord], block_height: uint32, validate_signature=True) -> Tuple[Optional[uint64], MempoolInclusionStatus, Optional[Err]]:
+def validate_spendbundle(new_spend: SpendBundle, mempool_removals: List[Coin], current_coin_records: List[CoinRecord], block_height: uint32, validate_signature=True, timestamp=None) -> Tuple[Optional[uint64], MempoolInclusionStatus, Optional[Err]]:
+    if timestamp is None:
+        timestamp = time.time()
+
     spend_name = new_spend.name()
     cost_result = NPCResult.from_bytes(validate_transaction(bytes(new_spend)))
 
@@ -205,7 +208,7 @@ def validate_spendbundle(new_spend: SpendBundle, mempool_removals: List[Coin], c
             puzzle_announcements_in_spend,
             npc.condition_dict,
             uint32(chialisp_height),
-            uint64(int(time.time()))
+            uint64(timestamp)
         )
 
         if error:

--- a/std/sim/spend_bundle_validation.py
+++ b/std/sim/spend_bundle_validation.py
@@ -193,6 +193,11 @@ def validate_spendbundle(new_spend: SpendBundle, mempool_removals: List[Coin], c
     coin_announcements_in_spend: Set[bytes32] = coin_announcements_names_for_npc(npc_list)
     puzzle_announcements_in_spend: Set[bytes32] = puzzle_announcements_names_for_npc(npc_list)
     for npc in npc_list:
+        # XXX this is a hack, but I'm unsure what npc_list represents or why it's
+        # necessarily true that things in it must exist in the remove list.
+        if npc.coin_name not in removal_record_dict:
+                continue
+
         coin_record: CoinRecord = removal_record_dict[npc.coin_name]
         # Check that the revealed removal puzzles actually match the puzzle hash
         if npc.puzzle_hash != coin_record.coin.puzzle_hash:

--- a/std/test/__init__.py
+++ b/std/test/__init__.py
@@ -493,7 +493,7 @@ class Wallet:
             solution = Program.to([[], delegated_puzzle_solution, []])
         else:
             delegated_puzzle_solution = Program.to(kwargs['args'])
-            solution = Program.to([[], delegated_puzzle_solution, []])
+            solution = delegated_puzzle_solution
 
         solution_for_coin = CoinSolution(
             coin,

--- a/std/test/__init__.py
+++ b/std/test/__init__.py
@@ -26,7 +26,6 @@ from lib.std.types.program import Program
 duration_div = 86400.0
 block_time = (600.0 / 32.0) / duration_div
 # Allowed subdivisions of 1 coin
-coin_mul = 1000000000000
 
 class SpendResult:
     def __init__(self,result):
@@ -116,8 +115,6 @@ class Wallet:
         if 'amt' in kwargs:
             amt = kwargs['amt']
 
-        amt = int(amt * coin_mul)
-
         found_coin = self.choose_coin(amt)
         if found_coin is None:
             raise ValueError(f'could not find available coin containing {amt} mojo')
@@ -170,8 +167,6 @@ class Wallet:
         amt = 1
         if 'amt' in kwargs:
             amt = kwargs['amt']
-
-        amt = int(amt * coin_mul)
 
         def pk_to_sk(pk: G1Element) -> PrivateKey:
             assert pk == self.pk()
@@ -289,6 +284,7 @@ class Network:
 
 class TestGroup(TestCase):
     def setUp(self):
+        self.coin_multiple = 1000000000000
         self.network = Network()
 
     def __init__(self,t):

--- a/std/test/__init__.py
+++ b/std/test/__init__.py
@@ -216,6 +216,7 @@ class Network:
         self.wallets = {}
         self.time = datetime.timedelta(0)
         self.node = Node()
+        self.node.set_timestamp(0.01)
         self.nobody = self.make_wallet('nobody')
         self.wallets[str(self.nobody.pk())] = self.nobody
 
@@ -258,14 +259,14 @@ class Network:
     def skip_time(self,t,**kwargs):
         target_duration = pytimeparse.parse(t)
         target_time = self.time + datetime.timedelta(target_duration / duration_div)
-        while target_time > self.time:
+        while target_time > self.get_timestamp():
             self.farm_block(**kwargs)
 
         # Or possibly aggregate farm_block results.
         return None
 
     def get_timestamp(self):
-        return self.time
+        return datetime.timedelta(seconds = self.node.timestamp)
 
     # Given a spend bundle, farm a block and analyze the result.
     def push_tx(self,bundle):

--- a/std/test/__init__.py
+++ b/std/test/__init__.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from blspy import AugSchemeMPL, G1Element, PrivateKey
 
 from clvm.serialize import sexp_from_stream
+from clvm import SExp
 
 from lib.std.types.sized_bytes import bytes32
 from lib.std.types.ints import uint64
@@ -31,6 +32,9 @@ class SpendResult:
     def __init__(self,result):
         self.result = result
         self.outputs = result['additions']
+
+    def find_standard_coins(self,puzzle_hash):
+        return list(filter(lambda x: x.puzzle_hash == puzzle_hash, self.outputs))
 
 class CoinWrapper(Coin):
     def __init__(self, parent : Coin, puzzle_hash : bytes32, amt : uint64, source : Program):
@@ -185,7 +189,7 @@ class Wallet:
             # Solution is the solution for the old coin.
             solution = Program.to([[], delegated_solution, []])
         else:
-            solution = Program.to([[], Program.to(kwargs['args']), []])
+            solution = Program.to(kwargs['args'])
 
         solution_for_coin = CoinSolution(
             coin,
@@ -259,6 +263,9 @@ class Network:
 
         # Or possibly aggregate farm_block results.
         return None
+
+    def get_timestamp(self):
+        return self.time
 
     # Given a spend bundle, farm a block and analyze the result.
     def push_tx(self,bundle):

--- a/std/test/__init__.py
+++ b/std/test/__init__.py
@@ -22,6 +22,11 @@ from lib.std.types.coin_signature import sign_coin_solutions
 from lib.std.types.coin import Coin
 from lib.std.spends.chialisp import sha256tree
 from lib.std.types.program import Program
+from lib.std.util.hash import std_hash
+
+CONDITION_CREATE_COIN = 51
+CONDITION_CREATE_COIN_ANNOUNCEMENT = 60
+CONDITION_ASSERT_COIN_ANNOUNCEMENT = 61
 
 duration_div = 86400.0
 block_time = (600.0 / 32.0) / duration_div
@@ -29,6 +34,12 @@ block_time = (600.0 / 32.0) / duration_div
 
 class SpendResult:
     def __init__(self,result):
+        """Constructor for internal use.
+
+        error - a string describing the error or None
+        result - the raw result from Network::push_tx
+        outputs - a list of new Coin objects surviving the transaction
+        """
         self.result = result
         if 'error' in result:
             self.error = result['error']
@@ -38,21 +49,48 @@ class SpendResult:
             self.outputs = result['additions']
 
     def find_standard_coins(self,puzzle_hash):
+        """Given a Wallet's puzzle_hash, find standard coins usable by it.
+
+        These coins are recognized as changing the Wallet's chia balance and are
+        usable for any purpose."""
         return list(filter(lambda x: x.puzzle_hash == puzzle_hash, self.outputs))
 
 class CoinWrapper(Coin):
+    """A class that provides some useful methods on coins."""
     def __init__(self, parent : Coin, puzzle_hash : bytes32, amt : uint64, source : Program):
+        """Given parent, puzzle_hash and amount, give an object representing the coin"""
         super().__init__(parent,puzzle_hash,amt)
         self.source = source
 
     def puzzle(self) -> Program:
+        """Return the program that unlocks this coin"""
         return self.source
 
     def puzzle_hash(self) -> bytes32:
+        """Return this coin's puzzle hash"""
         return self.puzzle().get_tree_hash()
 
     def contract(self):
+        """Return a contract object wrapping this coin's program"""
         return ContractWrapper(DEFAULT_CONSTANTS.GENESIS_CHALLENGE, self.source)
+
+    def create_standard_spend(self, priv, conditions):
+        delegated_puzzle_solution = Program.to((1, conditions))
+        solution = Program.to([[], delegated_puzzle_solution, []])
+
+        coin_solution_object = CoinSolution(
+            self,
+            self.puzzle(),
+            solution,
+        )
+
+        # Create a signature for each of these.  We'll aggregate them at the end.
+        signature = AugSchemeMPL.sign(
+            calculate_synthetic_secret_key(priv, DEFAULT_HIDDEN_PUZZLE_HASH),
+            (delegated_puzzle_solution.get_tree_hash() + self.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA)
+        )
+
+        return coin_solution_object, signature
 
 # We have two cases for coins:
 # - Wallet coins which contribute to the "wallet balance" of the user.
@@ -67,17 +105,51 @@ class CoinWrapper(Coin):
 #   coin is never destroyed.
 class ContractWrapper:
     def __init__(self,genesis_challenge,source):
+        """A wrapper for a contract carrying useful methods for interacting with chia."""
         self.genesis_challenge = genesis_challenge
         self.source = source
 
     def puzzle(self):
+        """Give this contract's program"""
         return self.source
 
     def puzzle_hash(self):
+        """Give this contract's puzzle hash"""
         return self.source.get_tree_hash()
 
     def custom_coin(self, parent : Coin, amt : uint64):
+        """Given a parent and an amount, create the Coin object representing this
+        contract as it would exist post launch"""
         return CoinWrapper(parent.name(), self.puzzle_hash(), amt, self.source)
+
+class CoinPairSearch:
+    def __init__(self,target_amount):
+        self.target = target_amount
+        self.best_fit = []
+        self.max_coins = []
+
+    def get_result(self):
+        return self.best_fit, self.max_coins
+
+    def process_coin_for_combine_search(self,coin):
+        # Update max
+        if len(self.max_coins) < 2:
+            self.max_coins = self.max_coins + [coin]
+        elif coin.amount > self.max_coins[0].amount:
+            self.max_coins = ([coin] + self.max_coins)[:2]
+        elif coin.amount > self.max_coins[1].amount:
+            self.max_coins = [self.max_coins[0], coin]
+
+        # Update best
+        if len(self.best_fit) < 2:
+            self.best_fit = self.best_fit + [coin]
+        else:
+            cur_best_fit_amount = sum(map(lambda x: x.amount, self.best_fit))
+            greater = 0 if self.best_fit[0].amount > self.best_fit[1].amount else 1
+            lesser = (greater + 1) % 2
+            candidate_bf_amount = self.best_fit[lesser].amount + coin.amount
+            if candidate_bf_amount < cur_best_fit_amount and candidate_bf_amount > self.target:
+                self.best_fit = [self.best_fit[lesser], coin]
 
 # A basic wallet that knows about standard coins.
 # We can use this to track our balance as an end user and keep track of chia
@@ -85,6 +157,17 @@ class ContractWrapper:
 # them, as many likely will.
 class Wallet:
     def __init__(self,parent,name,pk,priv):
+        """Internal use constructor, use Network::make_wallet
+
+        Fields:
+        parent - The Network object that created this Wallet
+        name - The textural name of the actor
+        pk_ - The actor's public key
+        priv_ - The actor's private key
+        usable_coins - Standard coins spendable by this actor
+        puzzle - A program for creating this actor's standard coin
+        puzzle_hash - The puzzle hash for this actor's standard coin
+        """
         self.parent = parent
         self.name = name
         self.pk_ = pk
@@ -93,17 +176,213 @@ class Wallet:
         self.puzzle = puzzle_for_pk(self.pk())
         self.puzzle_hash = self.puzzle.get_tree_hash()
 
+    def __repr__(self):
+        return f'<Wallet(name={self.name},puzzle_hash={self.puzzle_hash},pk={self.pk_})>'
+
     # Make this coin available to the user it goes with.
     def add_coin(self,coin):
         self.usable_coins[coin.name()] = coin
 
-    # Find a coin containing amt we can use as a parent.
-    def choose_coin(self,amt) -> CoinWrapper:
-        for k,c in self.usable_coins.items():
-            if c.amount >= amt:
-                return CoinWrapper(c.parent_coin_info, c.puzzle_hash, c.amount, self.puzzle)
+    def compute_combine_action(self,amt,actions,usable_coins):
+        # No point in going on if we're on our last dollar.
+        if len(usable_coins) < 2:
+            return None
 
-        return None
+        # No one coin is enough, try to find a best fit pair, otherwise combine the two
+        # maximum coins.
+        searcher = CoinPairSearch(amt)
+
+        # Process coins for this round.
+        for k,c in usable_coins.items():
+            searcher.process_coin_for_combine_search(c)
+
+        best_fit, max_coins = searcher.get_result()
+
+        # Best fit coins indicate we can combine just 2, so do that.
+        if len(best_fit) == 2:
+            return actions + [best_fit]
+        else:
+            del usable_coins[max_coins[0].name()]
+            del usable_coins[max_coins[1].name()]
+            new_coin = CoinWrapper(
+                max_coins[0],
+                self.puzzle_hash,
+                max_coins[0].amount + max_coins[1].amount,
+                self.puzzle
+            )
+            usable_coins[new_coin.name()] = new_coin
+            return compute_combine_action(amt, actions + [max_coins], usable_coins)
+
+    # Given some coins, combine them, causing the network to make us
+    # recompute our balance in return.
+    #
+    # This is a metaphor for the meaning of "solution" in the coin "puzzle program" context:
+    #
+    #     The arguments to the coin's puzzle program, which is the first kind
+    #     of object called a 'solution' in this case refers to the arguments
+    #     needed to cause the program to emit blockchain compatible opcodes.
+    #     It's a "puzzle" in the sense that a ctf RE exercise is a "puzzle".
+    #     "solving" it means producing input that causes the unknown program to
+    #     do something desirable.
+    #
+    # Spending multiple coins:
+    #   There are two running lists that need to be kept when spending multiple coins:
+    #
+    #   - A list of signatures.  Each coin has its own signature requirements, but standard
+    #     coins are signed like this:
+    #
+    #             AugSchemeMPL.sign(
+    #               calculate_synthetic_secret_key(self.priv_,DEFAULT_HIDDEN_PUZZLE_HASH),
+    #               (delegated_puzzle_solution.get_tree_hash() + c.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA)
+    #             )
+    #
+    #     where c.name is the coin's "name" (in the code) or coinID (in the
+    #     chialisp docs). delegated_puzzle_solution is a clvm program that
+    #     produces the arguments we want to give the puzzle program (the first
+    #     kind of 'solution').
+    #
+    #     In most cases, we'll give a tuple like (1, [some, python, [data,
+    #     here]]) for these arguments, because '1' is the quote function 'q' in
+    #     clvm. One could write this program with any valid clvm code though.
+    #     The important thing is that it's runnable code, not literal data as
+    #     one might expect.
+    #
+    #   - A list of CoinSolution objects.
+    #     Theese consist of (with c : Coin):
+    #
+    #             CoinSolution(
+    #               c,
+    #               c.puzzle(),
+    #               solution,
+    #             )
+    #
+    # Where solution is a second formulation of a 'solution' to a puzzle (the third form
+    # of 'solution' we'll use in this documentation is the CoinSolution object.).  This is
+    # related to the program arguments above, but prefixes and suffixes an empty list on
+    # them (admittedly i'm cargo culting this part):
+    #
+    # solution = Program.to([[], delegated_puzzle_solution, []])
+    #
+    # So you do whatever you want with a bunch of coins at once and now you have two lists:
+    # 1) A list of G1Element objects yielded by AugSchemeMPL.sign
+    # 2) A list of CoinSolution objects.
+    #
+    # Now to spend them at once:
+    #
+    #         signature = AugSchemeMPL.aggregate(signatures)
+    #         spend_bundle = SpendBundle(coin_solutions, signature)
+    #
+    def combine_coins(self,coins):
+        # Overall structure:
+        # Create len-1 spends that just assert that the final coin is created with full value.
+        # Create 1 spend for the final coin that asserts the other spends occurred and
+        # Creates the new coin.
+
+        beginning_balance = self.balance()
+        beginning_coins = len(self.usable_coins)
+
+        def pk_to_sk(pk: G1Element) -> PrivateKey:
+            assert pk == self.pk()
+            return self.priv_
+
+        # We need the final coin to know what the announced coin name will be.
+        final_coin = CoinWrapper(
+            coins[-1].name(),
+            self.puzzle_hash,
+            sum(map(lambda x: x.amount, coins)),
+            self.puzzle
+        )
+
+        destroyed_coin_solutions = []
+
+        # Each coin wants agg_sig_me so we aggregate them at the end.
+        signatures = []
+
+        for c in coins[:-1]:
+            announce_conditions = [
+                # each coin announces its name to alert the final coin that it spent
+                [
+                    CONDITION_CREATE_COIN_ANNOUNCEMENT,
+                    c.name()
+                ],
+                # Each coin expects the final coin creation announcement
+                [
+                    CONDITION_ASSERT_COIN_ANNOUNCEMENT,
+                    std_hash(coins[-1].name() + final_coin.name())
+                ]
+            ]
+
+            coin_solution, signature = c.create_standard_spend(self.priv_, announce_conditions)
+            destroyed_coin_solutions.append(coin_solution)
+            signatures.append(signature)
+
+        final_coin_creation = list(map(lambda x: [
+            CONDITION_ASSERT_COIN_ANNOUNCEMENT,
+            std_hash(c.name() + c.name()),
+        ], coins[:-1]))
+
+        final_coin_creation += [
+            [CONDITION_CREATE_COIN_ANNOUNCEMENT, final_coin.name()],
+            [CONDITION_CREATE_COIN, self.puzzle_hash, final_coin.amount],
+        ]
+
+        coin_solution, signature = coins[-1].create_standard_spend(self.priv_, final_coin_creation)
+        destroyed_coin_solutions.append(coin_solution)
+        signatures.append(signature)
+
+        signature = AugSchemeMPL.aggregate(signatures)
+        spend_bundle = SpendBundle(destroyed_coin_solutions, signature)
+
+        pushed = self.parent.push_tx(spend_bundle)
+
+        # We should have the same amount of money.
+        assert beginning_balance == self.balance()
+        # We should have shredded n-1 coins and replaced one.
+        assert len(self.usable_coins) == beginning_coins - (len(coins) - 1)
+
+        return SpendResult(pushed)
+
+    # Find a coin containing amt we can use as a parent.
+    # Synthesize a coin with sufficient funds if possible.
+    def choose_coin(self,amt) -> CoinWrapper:
+        """Given an amount requirement, find a coin that contains at least that much chia"""
+        best_fit_coin = None
+        for _ in range(1000):
+            for k,c in self.usable_coins.items():
+                if best_fit_coin is None and c.amount >= amt:
+                    best_fit_coin = c
+                elif c.amount >= amt and c.amount < best_fit_coin.amount:
+                    best_fit_coin = c
+                else:
+                    pass
+
+            if best_fit_coin is not None:
+                return best_fit_coin
+
+            actions_to_take = self.compute_combine_action(amt, [], dict(self.usable_coins))
+            # Couldn't find a working combination.
+            if actions_to_take is None:
+                return None
+
+            # We receive a timeline of actions to take (indicating that we have a plan)
+            # Do the first action and start over.
+            result = self.combine_coins(
+                list(
+                    map(
+                        lambda x:CoinWrapper(
+                            x.parent_coin_info,
+                            x.puzzle_hash,
+                            x.amount,
+                            self.puzzle
+                        ),
+                        actions_to_take[0]
+                    )
+                )
+            )
+
+            # Bugged out, couldn't combine for some reason.
+            if result is None:
+                return None
 
     # Create a new contract based on a parent coin and return the coin to the user.
     # TODO:
@@ -111,6 +390,8 @@ class Wallet:
     #  - ensure input chia = output chia.  it'd be dumb to just allow somebody
     #    to lose their chia without telling them.
     def launch_contract(self,source,**kwargs) -> CoinWrapper:
+        """Create a new contract based on a parent coin and return the contract's living
+        coin to the user or None if the spend failed."""
         amt = 1
         if 'amt' in kwargs:
             amt = kwargs['amt']
@@ -121,7 +402,15 @@ class Wallet:
 
         # Create a puzzle based on the incoming contract
         cw = ContractWrapper(DEFAULT_CONSTANTS.GENESIS_CHALLENGE, source)
-        delegated_puzzle_solution = Program.to((1, [[ConditionOpcode.CREATE_COIN, cw.puzzle_hash(), amt]]))
+        condition_args = [
+            [ConditionOpcode.CREATE_COIN, cw.puzzle_hash(), amt],
+        ]
+        if amt < found_coin.amount:
+            condition_args.append(
+                [ConditionOpcode.CREATE_COIN, self.puzzle_hash, found_coin.amount - amt]
+            )
+
+        delegated_puzzle_solution = Program.to((1, condition_args))
         solution = Program.to([[], delegated_puzzle_solution, []])
 
         # Sign the (delegated_puzzle_hash + coin_name) with synthetic secret key
@@ -146,16 +435,22 @@ class Wallet:
         else:
             return None
 
+    # Give chia
+    def give_chia(self, target, amt):
+        return self.launch_contract(target.puzzle, amt=amt)
+
     # Called each cycle before coins are re-established from the simulator.
     def _clear_coins(self):
         self.usable_coins = {}
 
     # Public key of wallet
     def pk(self):
+        """Return actor's public key"""
         return self.pk_
 
     # Balance of wallet
     def balance(self):
+        """Return the actor's balance in standard coins as we understand it"""
         return sum(map(lambda x: x.amount, self.usable_coins.values()))
 
     # Spend a coin, probably a contract coin.
@@ -164,6 +459,8 @@ class Wallet:
     # Result is an object representing the actions taken when the block
     # with this transaction was farmed.
     def spend_coin(self, coin : CoinWrapper, **kwargs):
+        """Given a coin object, invoke it on the blockchain, either as a standard
+        coin if no arguments are given or with custom arguments in args="""
         amt = 1
         if 'amt' in kwargs:
             amt = kwargs['amt']
@@ -173,8 +470,13 @@ class Wallet:
             return self.priv_
 
         if not 'args' in kwargs:
+            target_puzzle_hash = self.puzzle_hash
+            # Allow the user to 'give this much chia' to another user.
+            if 'to' in kwargs:
+                target_puzzle_hash = kwargs['to'].puzzle_hash
+
             # Automatic arguments from the user's intention.
-            solution_list = [[ConditionOpcode.CREATE_COIN, self.puzzle_hash, amt]]
+            solution_list = [[ConditionOpcode.CREATE_COIN, target_puzzle_hash, amt]]
             if 'remain' in kwargs:
                 remainer = kwargs['remain']
                 remain_amt = coin.amount - amt
@@ -197,6 +499,12 @@ class Wallet:
             solution,
         )
 
+        # Sign the (delegated_puzzle_hash + coin_name) with synthetic secret key
+        signature = AugSchemeMPL.sign(
+            calculate_synthetic_secret_key(self.priv_,DEFAULT_HIDDEN_PUZZLE_HASH),
+            (delegated_puzzle_solution.get_tree_hash() + found_coin.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA)
+        )
+
         spend_bundle = sign_coin_solutions(
             [solution_for_coin],
             pk_to_sk,
@@ -205,13 +513,12 @@ class Wallet:
         )
 
         pushed = self.parent.push_tx(SpendBundle.from_chia_spend_bundle(spend_bundle))
-        if 'error' not in pushed:
-            return SpendResult(pushed)
-        else:
-            return SpendResult(pushed)
+        return SpendResult(pushed)
 
 # A user oriented (domain specific) view of the chia network.
 class Network:
+    """An object that owns a node simulation, responsible for managing Wallet actors,
+    time and initialization."""
     def __init__(self):
         self.wallets = {}
         self.time = datetime.timedelta(0)
@@ -222,6 +529,11 @@ class Network:
 
     # Have the system farm one block with a specific beneficiary (nobody if not specified).
     def farm_block(self,**kwargs):
+        """Given a farmer, farm a block with that actor as the beneficiary of the farm
+        reward.
+
+        Used for causing chia balance to exist so the system can do things.
+        """
         farmer = self.nobody
         if 'farmer' in kwargs:
             farmer = kwargs['farmer']
@@ -250,6 +562,9 @@ class Network:
     # This results in the creation of a wallet that tracks balance and standard coins.
     # Public and private key from here are used in signing.
     def make_wallet(self,name):
+        """Create a wallet for an actor.  This causes the actor's chia balance in standard
+        coin to be tracked during the simulation.  Wallets have some domain specific methods
+        that behave in similar ways to other blockchains."""
         pk, priv = self._alloc_key()
         w = Wallet(self, name, pk, priv)
         self.wallets[str(w.pk())] = w
@@ -257,6 +572,8 @@ class Network:
 
     # Skip real time by farming blocks until the target duration is achieved.
     def skip_time(self,t,**kwargs):
+        """Skip a duration of simulated time, causing blocks to be farmed.  If a farmer
+        is specified, they win each block"""
         target_duration = pytimeparse.parse(t)
         target_time = self.time + datetime.timedelta(target_duration / duration_div)
         while target_time > self.get_timestamp():
@@ -266,26 +583,35 @@ class Network:
         return None
 
     def get_timestamp(self):
+        """Return the current simualtion time in seconds."""
         return datetime.timedelta(seconds = self.node.timestamp)
 
     # Given a spend bundle, farm a block and analyze the result.
-    def push_tx(self,bundle):
+    def push_tx(self,bundle,more=False):
+        """Given a spend bundle, try to farm a block containing it.  If the spend bundle
+        didn't validate, then a result containing an 'error' key is returned.  The reward
+        for the block goes to Network::nobody"""
         try:
             res = self.node.push_tx(bundle)
         except ValueError as e:
             return { "error": str(e) }
 
-        results = self.farm_block()
-        return {
-            'cost': res['cost'],
-            'additions': results['additions'],
-            'removals': results['removals']
-        }
+        if not more:
+            # Common case that we want to farm this right away.
+            results = self.farm_block()
+            return {
+                'cost': res['cost'],
+                'additions': results['additions'],
+                'removals': results['removals']
+            }
+        else:
+            return {'cost': 0, 'additions':[], 'removals': []}
 
 class TestGroup(TestCase):
     def setUp(self):
         self.coin_multiple = 1000000000000
         self.network = Network()
+        self.network.farm_block() # gives 21000000 chia!
 
     def __init__(self,t):
         super().__init__(t)

--- a/std/test/__init__.py
+++ b/std/test/__init__.py
@@ -1,0 +1,243 @@
+import io
+import datetime
+import pytimeparse
+from unittest import TestCase
+from blspy import AugSchemeMPL
+
+from clvm.serialize import sexp_from_stream
+
+from lib.std.types.sized_bytes import bytes32
+from lib.std.types.ints import uint64
+from lib.std.util.keys import public_key_for_index, private_key_for_index
+from lib.std.sim.node import Node
+from lib.std.types.program import Program
+from lib.std.util.condition_tools import ConditionOpcode, conditions_by_opcode
+from lib.std.spends.p2_delegated_puzzle_or_hidden_puzzle import puzzle_for_pk, solution_for_delegated_puzzle, calculate_synthetic_secret_key # standard_transaction
+from lib.std.spends.defaults import DEFAULT_HIDDEN_PUZZLE, DEFAULT_HIDDEN_PUZZLE_HASH
+from lib.std.sim.default_constants import DEFAULT_CONSTANTS
+from lib.std.types.spend_bundle import SpendBundle
+from lib.std.types.coin_solution import CoinSolution
+from lib.std.types.coin import Coin
+from lib.std.spends.chialisp import sha256tree
+from lib.std.types.program import Program
+
+duration_div = 86400.0
+block_time = (600.0 / 32.0) / duration_div
+# Allowed subdivisions of 1 coin
+coin_mul = 1000000000000
+
+class SpendResult:
+    def __init__(self):
+        self.outputs = []
+
+class CoinWrapper(Coin):
+    def __init__(self, parent : Coin, puzzle_hash : bytes32, amt : uint64, source : Program):
+        super().__init__(parent,puzzle_hash,amt)
+        self.source = source
+
+    def puzzle(self) -> Program:
+        return self.source
+
+    def puzzle_hash(self) -> bytes32:
+        return self.puzzle().get_tree_hash()
+
+    def contract(self):
+        return ContractWrapper(DEFAULT_CONSTANTS.GENESIS_CHALLENGE, self.source)
+
+# We have two cases for coins:
+# - Wallet coins which contribute to the "wallet balance" of the user.
+#   They enable a user to "spend money" and "take actions on the network"
+#   that have monetary value.
+#
+# - Contract coins which either lock value or embody information and
+#   services.  These also contain a chia balance but are used for purposes
+#   other than a fungible, liquid, spendable resource.  They should not show
+#   up in a "wallet" in the same way.  We should use them by locking value
+#   into wallet coins.  We should ensure that value contained in a contract
+#   coin is never destroyed.
+class ContractWrapper:
+    def __init__(self,genesis_challenge,source):
+        self.genesis_challenge = genesis_challenge
+        self.source = source
+
+    def puzzle(self):
+        return self.source
+
+    def puzzle_hash(self):
+        return self.source.get_tree_hash()
+
+    def custom_coin(self, parent : Coin, amt : uint64):
+        return CoinWrapper(parent.name(), self.puzzle_hash(), amt, self.source)
+
+class Wallet:
+    def __init__(self,parent,name,pk,priv):
+        self.parent = parent
+        self.name = name
+        self.pk_ = pk
+        self.priv_ = priv
+        self.usable_coins = {}
+        self.puzzle = puzzle_for_pk(self.pk())
+        self.puzzle_hash = self.puzzle.get_tree_hash()
+
+    # Make this coin available to the user it goes with.
+    def add_coin(self,coin):
+        self.usable_coins[(coin.parent_coin_info,coin.puzzle_hash)] = coin
+
+    # Find a coin containing amt we can use as a parent.
+    def choose_coin(self,amt) -> CoinWrapper:
+        for k,c in self.usable_coins.items():
+            if c.amount >= amt:
+                return CoinWrapper(c.parent_coin_info, c.puzzle_hash, c.amount, self.puzzle)
+
+        return None
+
+    # Create a new contract based on a parent coin.
+    def launch_contract(self,source,**kwargs) -> CoinWrapper:
+        amt = 1
+        if 'amt' in kwargs:
+            amt = kwargs['amt']
+
+        amt = int(amt * coin_mul)
+
+        found_coin = self.choose_coin(amt)
+        if found_coin is None:
+            raise ValueError(f'could not find available coin containing {amt} mojo')
+
+        print(f'spending coin {found_coin} with name {found_coin.name()}')
+
+        # Create a puzzle based on the incoming contract
+        cw = ContractWrapper(DEFAULT_CONSTANTS.GENESIS_CHALLENGE, source)
+        delegated_puzzle_solution = Program.to((1, [[ConditionOpcode.CREATE_COIN, cw.puzzle_hash(), amt]]))
+        solution = Program.to([[], delegated_puzzle_solution, []])
+        print(f'solution1 {solution}')
+
+        # Sign the (delegated_puzzle_hash + coin_name) with synthetic secret key
+        signature = AugSchemeMPL.sign(
+            calculate_synthetic_secret_key(self.priv_,DEFAULT_HIDDEN_PUZZLE_HASH),
+            (delegated_puzzle_solution.get_tree_hash() + found_coin.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA)
+        )
+
+        spend_bundle = SpendBundle(
+            [
+                CoinSolution(
+                    found_coin, # Coin to spend
+                    self.puzzle, # Puzzle used for found_coin
+                    solution, # The solution to the puzzle locking found_coin
+                )
+            ]
+            , signature
+        )
+        pushed = self.parent.push_tx(spend_bundle)
+        if pushed:
+            return cw.custom_coin(found_coin, amt)
+        else:
+            return None
+
+    def clear_coins(self):
+        self.usable_coins = {}
+
+    def pk(self):
+        return self.pk_
+
+    def balance(self):
+        return 0
+
+    def spend_coin(self,coin : CoinWrapper,**kwargs):
+        amt = 1
+        if 'amt' in kwargs:
+            amt = kwargs['amt']
+
+        amt = int(amt * coin_mul)
+
+        solution_list = [[ConditionOpcode.CREATE_COIN, self.puzzle_hash, amt]]
+        if 'remain' in kwargs:
+            remainer = kwargs['remain']
+            remain_amt = coin.amount - amt
+            if isinstance(remainer, ContractWrapper):
+                solution_list.append([ConditionOpcode.CREATE_COIN, remainer.puzzle_hash(), remain_amt])
+            elif isinstance(remainer, Wallet):
+                solution_list.append([ConditionOpcode.CREATE_COIN, remainer.puzzle_hash, remain_amt])
+            else:
+                raise ValueError("remainer is not a waller or a contract")
+
+        delegated_solution = Program.to((1, solution_list))
+        # Our user's puzzle
+        solution = Program.to([[], delegated_solution, []])
+        print(f'solution2 {solution}')
+        signature = AugSchemeMPL.sign(
+            calculate_synthetic_secret_key(self.priv_,DEFAULT_HIDDEN_PUZZLE_HASH),
+            (solution.get_tree_hash() + coin.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA)
+        )
+
+        spend_bundle = SpendBundle(
+            [
+                CoinSolution(
+                    coin, # coin
+                    coin.puzzle(), # puzzle reveal
+                    solution, # puzzle solution
+                )
+            ]
+            , signature
+        )
+
+        print(spend_bundle)
+        pushed = self.parent.push_tx(spend_bundle)
+        if pushed:
+            return SpendResult(pushed).outputs[0]
+        else:
+            return None
+
+# A user oriented (domain specific) view of the chia network.
+class Network:
+    def __init__(self):
+        self.wallets = {}
+        self.time = datetime.timedelta(0)
+        self.node = Node()
+        self.nobody = self.make_wallet('nobody')
+        self.wallets[str(self.nobody.pk())] = self.nobody
+
+    def farm_block(self,**kwargs):
+        farmer = self.nobody
+        if 'farmer' in kwargs:
+            farmer = kwargs['farmer']
+
+        farm_duration = datetime.timedelta(block_time)
+        self.node.farm_block(farmer.pk())
+
+        for k, w in self.wallets.items():
+            w.clear_coins()
+
+        for coin in self.node.coins:
+            for kw, w in self.wallets.items():
+                if coin.puzzle_hash == w.puzzle_hash:
+                    w.add_coin(coin)
+
+        self.time += farm_duration
+
+    def alloc_key(self):
+        key_idx = len(self.wallets)
+        pk = public_key_for_index(key_idx)
+        priv = private_key_for_index(key_idx)
+        return pk, priv
+
+    def make_wallet(self,name):
+        pk, priv = self.alloc_key()
+        w = Wallet(self, name, pk, priv)
+        self.wallets[str(w.pk())] = w
+        return w
+
+    def skip_time(self,t,**kwargs):
+        target_duration = pytimeparse.parse(t)
+        target_time = self.time + datetime.timedelta(target_duration / duration_div)
+        while target_time > self.time:
+            self.farm_block(**kwargs)
+
+    def push_tx(self,bundle):
+        return self.node.push_tx(bundle)
+
+class TestGroup(TestCase):
+    def setUp(self):
+        self.network = Network()
+
+    def __init__(self,t):
+        super().__init__(t)

--- a/std/types/coin_signature.py
+++ b/std/types/coin_signature.py
@@ -1,4 +1,3 @@
-# XXX Pull in
 import asyncio
 from blspy import G1Element
 import chia.wallet.sign_coin_solutions as scs
@@ -26,6 +25,8 @@ async def call_sign_coin_solutions(
     )
     future.take_result(r)
 
+# Invokes chia's sign_coin_solutions and return a local style spend bundle.
+# This is here because it does the right thing for nonstandard coin invocations.
 def sign_coin_solutions(
         coin_solutions,
         secret_key_for_public_key_f,
@@ -34,4 +35,4 @@ def sign_coin_solutions(
 ) -> SpendBundle:
     bf = BasicFuture()
     asyncio.run(call_sign_coin_solutions(bf, coin_solutions, secret_key_for_public_key_f, additional_data, max_cost))
-    return bf.contents
+    return SpendBundle.from_chia_spend_bundle(bf.contents)

--- a/std/types/coin_signature.py
+++ b/std/types/coin_signature.py
@@ -1,0 +1,37 @@
+# XXX Pull in
+import asyncio
+from blspy import G1Element
+import chia.wallet.sign_coin_solutions as scs
+from lib.std.types.spend_bundle import SpendBundle
+
+class BasicFuture:
+    def __init__(self):
+        self.contents = None
+
+    def take_result(self,r):
+        self.contents = r
+
+async def call_sign_coin_solutions(
+        future : BasicFuture,
+        coin_solutions,
+        secret_key_for_public_key_f,
+        additional_data: bytes,
+        max_cost: int,
+) -> SpendBundle:
+    r = await scs.sign_coin_solutions(
+        coin_solutions,
+        secret_key_for_public_key_f,
+        additional_data,
+        max_cost
+    )
+    future.take_result(r)
+
+def sign_coin_solutions(
+        coin_solutions,
+        secret_key_for_public_key_f,
+        additional_data: bytes,
+        max_cost: int,
+) -> SpendBundle:
+    bf = BasicFuture()
+    asyncio.run(call_sign_coin_solutions(bf, coin_solutions, secret_key_for_public_key_f, additional_data, max_cost))
+    return bf.contents

--- a/std/types/coin_signature.py
+++ b/std/types/coin_signature.py
@@ -1,7 +1,51 @@
+import blspy
+from blspy import AugSchemeMPL, G1Element, PrivateKey
+from typing import Callable, List, Optional
 import asyncio
-from blspy import G1Element
-import chia.wallet.sign_coin_solutions as scs
+
 from lib.std.types.spend_bundle import SpendBundle
+
+from lib.std.types.coin_solution import CoinSolution
+from lib.std.types.spend_bundle import SpendBundle
+from lib.std.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
+
+async def chia_sign_coin_solutions(
+    coin_solutions: List[CoinSolution],
+    secret_key_for_public_key_f: Callable[[blspy.G1Element], Optional[PrivateKey]],
+    additional_data: bytes,
+    max_cost: int,
+) -> SpendBundle:
+    signatures: List[blspy.G2Element] = []
+    pk_list: List[blspy.G1Element] = []
+    msg_list: List[bytes] = []
+    for coin_solution in coin_solutions:
+        # Get AGG_SIG conditions
+        err, conditions_dict, cost = conditions_dict_for_solution(
+            coin_solution.puzzle_reveal, coin_solution.solution, max_cost
+        )
+        if err or conditions_dict is None:
+            error_msg = f"Sign transaction failed, con:{conditions_dict}, error: {err}"
+            raise ValueError(error_msg)
+
+        # Create signature
+        for pk, msg in pkm_pairs_for_conditions_dict(
+            conditions_dict, bytes(coin_solution.coin.name()), additional_data
+        ):
+            pk_list.append(pk)
+            msg_list.append(msg)
+            secret_key = secret_key_for_public_key_f(pk)
+            if secret_key is None:
+                e_msg = f"no secret key for {pk}"
+                raise ValueError(e_msg)
+            assert bytes(secret_key.get_g1()) == bytes(pk)
+            signature = AugSchemeMPL.sign(secret_key, msg)
+            assert AugSchemeMPL.verify(pk, msg, signature)
+            signatures.append(signature)
+
+    # Aggregate signatures
+    aggsig = AugSchemeMPL.aggregate(signatures)
+    assert AugSchemeMPL.aggregate_verify(pk_list, msg_list, aggsig)
+    return SpendBundle(coin_solutions, aggsig)
 
 class BasicFuture:
     def __init__(self):
@@ -17,7 +61,7 @@ async def call_sign_coin_solutions(
         additional_data: bytes,
         max_cost: int,
 ) -> SpendBundle:
-    r = await scs.sign_coin_solutions(
+    r = await chia_sign_coin_solutions(
         coin_solutions,
         secret_key_for_public_key_f,
         additional_data,
@@ -35,4 +79,4 @@ def sign_coin_solutions(
 ) -> SpendBundle:
     bf = BasicFuture()
     asyncio.run(call_sign_coin_solutions(bf, coin_solutions, secret_key_for_public_key_f, additional_data, max_cost))
-    return SpendBundle.from_chia_spend_bundle(bf.contents)
+    return bf.contents

--- a/std/types/spend_bundle.py
+++ b/std/types/spend_bundle.py
@@ -24,13 +24,6 @@ class SpendBundle(Streamable):
     aggregated_signature: G2Element
 
     @classmethod
-    # Used to convert a chia style spend bundle to the local style when returned from
-    # chia's coin signature method as exposed by std.types.coin_signature.sign_coin_solutions
-    # which is used to sign nonstandard coin spends (such as bespoke coins you make yourself).
-    def from_chia_spend_bundle(cls, bundle):
-        return SpendBundle(bundle.coin_solutions, bundle.aggregated_signature)
-
-    @classmethod
     def aggregate(cls, spend_bundles) -> "SpendBundle":
         coin_solutions: List[CoinSolution] = []
         sigs: List[G2Element] = []

--- a/std/types/spend_bundle.py
+++ b/std/types/spend_bundle.py
@@ -24,6 +24,10 @@ class SpendBundle(Streamable):
     aggregated_signature: G2Element
 
     @classmethod
+    def from_chia_spend_bundle(cls, bundle):
+        return SpendBundle(bundle.coin_solutions, bundle.aggregated_signature)
+
+    @classmethod
     def aggregate(cls, spend_bundles) -> "SpendBundle":
         coin_solutions: List[CoinSolution] = []
         sigs: List[G2Element] = []

--- a/std/types/spend_bundle.py
+++ b/std/types/spend_bundle.py
@@ -24,6 +24,9 @@ class SpendBundle(Streamable):
     aggregated_signature: G2Element
 
     @classmethod
+    # Used to convert a chia style spend bundle to the local style when returned from
+    # chia's coin signature method as exposed by std.types.coin_signature.sign_coin_solutions
+    # which is used to sign nonstandard coin spends (such as bespoke coins you make yourself).
     def from_chia_spend_bundle(cls, bundle):
         return SpendBundle(bundle.coin_solutions, bundle.aggregated_signature)
 

--- a/tests/test_multispend.py
+++ b/tests/test_multispend.py
@@ -1,0 +1,24 @@
+from lib.std.test import TestGroup
+
+class CoinTests(TestGroup):
+    def test_multi_spend(self):
+        alice = self.network.make_wallet('alice')
+        bob = self.network.make_wallet('bob')
+
+        # Farm for alice
+        self.network.farm_block(farmer=alice)
+        self.network.farm_block(farmer=alice)
+
+        alice_start_balance = alice.balance()
+        bob_start_balance = bob.balance()
+
+        use_amount = 3 * self.coin_multiple
+
+        # Give 3 chia (for which we won't have a single coin big enough)
+        # to bob.  This will only work if we're combining coins.
+        result = alice.give_chia(bob, use_amount)
+
+        assert result
+
+        assert bob.balance() == bob_start_balance + use_amount
+        assert alice.balance() == alice_start_balance - use_amount

--- a/tests/test_multispend.py
+++ b/tests/test_multispend.py
@@ -12,7 +12,7 @@ class CoinTests(TestGroup):
         alice_start_balance = alice.balance()
         bob_start_balance = bob.balance()
 
-        # Give 3 chia (for which we won't have a single coin big enough)
+        # Give 'amount' chia (for which we won't have a single coin big enough)
         # to bob.  This will only work if we're combining coins.
         result = alice.give_chia(bob, use_amount)
 

--- a/tests/test_multispend.py
+++ b/tests/test_multispend.py
@@ -1,7 +1,7 @@
 from lib.std.test import TestGroup
 
 class CoinTests(TestGroup):
-    def test_multi_spend(self):
+    def do_multi_spend(self,use_amount):
         alice = self.network.make_wallet('alice')
         bob = self.network.make_wallet('bob')
 
@@ -12,8 +12,6 @@ class CoinTests(TestGroup):
         alice_start_balance = alice.balance()
         bob_start_balance = bob.balance()
 
-        use_amount = 3 * self.coin_multiple
-
         # Give 3 chia (for which we won't have a single coin big enough)
         # to bob.  This will only work if we're combining coins.
         result = alice.give_chia(bob, use_amount)
@@ -22,3 +20,15 @@ class CoinTests(TestGroup):
 
         assert bob.balance() == bob_start_balance + use_amount
         assert alice.balance() == alice_start_balance - use_amount
+
+    def test_1_chia(self):
+        self.do_multi_spend(1 * self.coin_multiple)
+
+    def test_2_chia(self):
+        self.do_multi_spend(2 * self.coin_multiple)
+
+    def test_3_chia(self):
+        self.do_multi_spend(3 * self.coin_multiple)
+
+    def test_4_chia(self):
+        self.do_multi_spend(4 * self.coin_multiple)


### PR DESCRIPTION
https://gist.github.com/prozacchiwawa/bae5686c8be6c1ef3595f983c67dc6b6 <-- example test cases using this support

We now support spending chia in a consistent way that should allow the user to focus on the actions of the contract elements.
I think this should be taken in its current form as it is practially useful even as it can be improved.